### PR TITLE
added updated for delete lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ terraform
 
 # Ignore idea folders and files
 .idea/
+
+examples/scratch

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ REGISTRY=registry.terraform.io
 HOSTNAME=aidanmelen
 NAME=snowsql
 BINARY=terraform-provider-${NAME}
-VERSION=0.2.0
+VERSION=0.3.0
 OS_ARCH=darwin_amd64
 
 default: install

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     snowsql = {
       source  = "aidanmelen/snowsql"
-      version = ">= 0.2.0"
+      version = ">= 0.3.0"
     }
   }
 }
@@ -48,7 +48,7 @@ terraform {
     }
     snowsql = {
       source  = "aidanmelen/snowsql"
-      version = ">= 0.2.0"
+      version = ">= 0.3.0"
     }
   }
 }

--- a/docs/resources/exec.md
+++ b/docs/resources/exec.md
@@ -26,7 +26,7 @@ terraform {
     }
     snowsql = {
       source  = "aidanmelen/snowsql"
-      version = ">= 0.2.0"
+      version = ">= 0.3.0"
     }
     random = ">= 2.1"
   }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -23,7 +23,7 @@ Run `terraform destroy` when you don't need these resources.
 | terraform | >= 0.13.0 |
 | random | >= 2.1 |
 | snowflake | >= 0.25.18 |
-| snowsql | >= 0.2.0 |
+| snowsql | >= 0.3.0 |
 
 ## Providers
 

--- a/examples/complete/modules/snowsql_exec_from_templates/README.md
+++ b/examples/complete/modules/snowsql_exec_from_templates/README.md
@@ -25,13 +25,13 @@ workspace-root
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.9 |
-| snowsql | >= 0.2.0 |
+| snowsql | >= 0.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| snowsql | >= 0.2.0 |
+| snowsql | >= 0.3.0 |
 | template | n/a |
 
 ## Inputs

--- a/examples/complete/modules/snowsql_exec_from_templates/versions.tf
+++ b/examples/complete/modules/snowsql_exec_from_templates/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     snowsql = {
       source  = "aidanmelen/snowsql"
-      version = ">= 0.2.0"
+      version = ">= 0.3.0"
     }
   }
 }

--- a/examples/complete/provider.tf
+++ b/examples/complete/provider.tf
@@ -8,7 +8,7 @@ terraform {
     }
     snowsql = {
       source  = "aidanmelen/snowsql"
-      version = ">= 0.2.0"
+      version = ">= 0.3.0"
     }
     random = ">= 2.1"
   }

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which can cost money (Warehouse, Dat
 | terraform | >= 0.13.0 |
 | random | >= 2.1 |
 | snowflake | >= 0.25.18 |
-| snowsql | >= 0.2.0 |
+| snowsql | >= 0.3.0 |
 
 ## Providers
 
@@ -30,7 +30,7 @@ Note that this example may create resources which can cost money (Warehouse, Dat
 |------|---------|
 | random | >= 2.1 |
 | snowflake | >= 0.25.18 |
-| snowsql | >= 0.2.0 |
+| snowsql | >= 0.3.0 |
 
 ## Inputs
 

--- a/examples/simple/provider.tf
+++ b/examples/simple/provider.tf
@@ -8,7 +8,7 @@ terraform {
     }
     snowsql = {
       source  = "aidanmelen/snowsql"
-      version = ">= 0.2.0"
+      version = ">= 0.3.0"
     }
     random = ">= 2.1"
   }

--- a/snowsql/resource_exec.go
+++ b/snowsql/resource_exec.go
@@ -11,7 +11,7 @@ import (
 	"github.com/snowflakedb/gosnowflake"
 )
 
-var lifecycleSchema = map[string]*schema.Schema{
+var createLifecycleSchema = map[string]*schema.Schema{
 	"statements": {
 		Type:        schema.TypeString,
 		Required:    true,
@@ -34,10 +34,34 @@ var lifecycleSchema = map[string]*schema.Schema{
 	},
 }
 
+var deleteLifecycleSchema = map[string]*schema.Schema{
+	"statements": {
+		Type:        schema.TypeString,
+		Required:    true,
+		ForceNew:    false,
+		Description: "A string containing one or many SnowSQL statements separated by semicolons.",
+		ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+			v := val.(string)
+			if v == "" {
+				errs = append(errs, fmt.Errorf("%q cannot be an empty string", key))
+			}
+			return
+		},
+	},
+	"number_of_statements": {
+		Type:        schema.TypeInt,
+		Optional:    true,
+		ForceNew:    false,
+		Default:     -1,
+		Description: "Specifies the number of SnowSQL statements. Defaults to `-1` which will dynamically count the number semicolons in SnowSQL statements. Go [here](https://godoc.org/github.com/snowflakedb/gosnowflake#hdr-Executing_Multiple_Statements_in_One_Call) to learn more about preventing SQL injection attacks.",
+	},
+}
+
 func resourceExec() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceExecCreate,
 		ReadContext:   resourceExecRead,
+		UpdateContext: resourceExecUpdate,
 		DeleteContext: resourceExecDelete,
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -53,17 +77,17 @@ func resourceExec() *schema.Resource {
 				ForceNew:    true,
 				Description: "Specifies the SnowSQL create lifecycle.",
 				Elem: &schema.Resource{
-					Schema: lifecycleSchema,
+					Schema: createLifecycleSchema,
 				},
 			},
 			"delete": {
 				Type:        schema.TypeList,
 				Required:    true,
 				MaxItems:    1,
-				ForceNew:    true,
+				ForceNew:    false,
 				Description: "Specifies the SnowSQL delete lifecycle.",
 				Elem: &schema.Resource{
-					Schema: lifecycleSchema,
+					Schema: deleteLifecycleSchema,
 				},
 			},
 			"delete_on_create": {
@@ -122,6 +146,14 @@ func resourceExecCreate(ctx context.Context, d *schema.ResourceData, m interface
 // resourceExecRead is not implemented and stubbed out because it is required.
 func resourceExecRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	return diags
+}
+
+func resourceExecUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// https://github.com/aidanmelen/terraform-provider-snowsql/issues/11
+
 	return diags
 }
 


### PR DESCRIPTION
- Added updated for delete lifecycle.
- The create lifecycle still requires force replacement to avoid spurious snowflake object creation.

# Scenario 1

update delete statement.

```hcl
resource "snowsql_exec" "use_utc_timezone_for_account" {
  name  = "snowflake-timezone-parameter-utc"

  create {
    statements = <<-EOT
      ALTER ACCOUNT SET TIMEZONE = 'UTC'
    EOT
  }

  delete {
    statements = <<-EOT
      ALTER ACCOUNT SET TIMEZONE = 'UTC'
    EOT
  }

  delete_on_create = false
}

```

```
$ terraform apply --auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # snowsql_exec.use_utc_timezone_for_account will be created
  + resource "snowsql_exec" "use_utc_timezone_for_account" {
      + delete_on_create = false
      + id               = (known after apply)
      + name             = "snowflake-timezone-parameter-utc"

      + create {
          + number_of_statements = -1
          + statements           = <<-EOT
                ALTER ACCOUNT SET TIMEZONE = 'UTC'
            EOT
        }

      + delete {
          + number_of_statements = -1
          + statements           = <<-EOT
                ALTER ACCOUNT UNSET TIMEZONE = 'UTC'
            EOT
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
snowsql_exec.use_utc_timezone_for_account: Creating...
snowsql_exec.use_utc_timezone_for_account: Creation complete after 1s [id=snowflake-timezone-parameter-utc]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

update delete statement

```
$ terraform apply --auto-approve
snowsql_exec.use_utc_timezone_for_account: Refreshing state... [id=snowflake-timezone-parameter-utc]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # snowsql_exec.use_utc_timezone_for_account will be updated in-place
  ~ resource "snowsql_exec" "use_utc_timezone_for_account" {
        id               = "snowflake-timezone-parameter-utc"
        name             = "snowflake-timezone-parameter-utc"
        # (1 unchanged attribute hidden)


      ~ delete {
          ~ statements           = <<-EOT
              - ALTER ACCOUNT UNSET TIMEZONE = 'UTC'
              + ALTER ACCOUNT UNSET TIMEZONE
            EOT
            # (1 unchanged attribute hidden)
        }
        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
snowsql_exec.use_utc_timezone_for_account: Modifying... [id=snowflake-timezone-parameter-utc]
snowsql_exec.use_utc_timezone_for_account: Modifications complete after 0s [id=snowflake-timezone-parameter-utc]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

destroy with updated delete statement

```
$ terraform destroy --auto-approve
snowsql_exec.use_utc_timezone_for_account: Refreshing state... [id=snowflake-timezone-parameter-utc]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # snowsql_exec.use_utc_timezone_for_account will be destroyed
  - resource "snowsql_exec" "use_utc_timezone_for_account" {
      - delete_on_create = false -> null
      - id               = "snowflake-timezone-parameter-utc" -> null
      - name             = "snowflake-timezone-parameter-utc" -> null

      - create {
          - number_of_statements = -1 -> null
          - statements           = <<-EOT
                ALTER ACCOUNT SET TIMEZONE = 'UTC'
            EOT -> null
        }

      - delete {
          - number_of_statements = -1 -> null
          - statements           = <<-EOT
                ALTER ACCOUNT UNSET TIMEZONE
            EOT -> null
        }
    }

Plan: 0 to add, 0 to change, 1 to destroy.
snowsql_exec.use_utc_timezone_for_account: Destroying... [id=snowflake-timezone-parameter-utc]
snowsql_exec.use_utc_timezone_for_account: Destruction complete after 1s

Destroy complete! Resources: 1 destroyed.
```

# Scenario 2

force replace when create statement changes.

```hcl
resource "snowsql_exec" "use_utc_timezone_for_account" {
  name  = "snowflake-timezone-parameter-utc"

  create {
    statements = <<-EOT
      ALTER ACCOUNT SET TIMEZONE = 'UTC'
    EOT
  }

  delete {
    statements = <<-EOT
      ALTER ACCOUNT SET TIMEZONE = 'UTC'
    EOT
  }

  delete_on_create = false
}

```

```
$ terraform apply --auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # snowsql_exec.use_utc_timezone_for_account will be created
  + resource "snowsql_exec" "use_utc_timezone_for_account" {
      + delete_on_create = false
      + id               = (known after apply)
      + name             = "snowflake-timezone-parameter-utc"

      + create {
          + number_of_statements = -1
          + statements           = <<-EOT
                ALTER ACCOUNT SET TIMEZONE = 'UTC'
            EOT
        }

      + delete {
          + number_of_statements = -1
          + statements           = <<-EOT
                ALTER ACCOUNT UNSET TIMEZONE
            EOT
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
snowsql_exec.use_utc_timezone_for_account: Creating...
snowsql_exec.use_utc_timezone_for_account: Creation complete after 0s [id=snowflake-timezone-parameter-utc]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

change TZ from `UTC` to `MST`. Changing the create statement will result in a force replace.

```
$ terraform apply --auto-approve
snowsql_exec.use_utc_timezone_for_account: Refreshing state... [id=snowflake-timezone-parameter-utc]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # snowsql_exec.use_utc_timezone_for_account must be replaced
-/+ resource "snowsql_exec" "use_utc_timezone_for_account" {
      ~ id               = "snowflake-timezone-parameter-utc" -> (known after apply)
        name             = "snowflake-timezone-parameter-utc"
        # (1 unchanged attribute hidden)

      ~ create {
          ~ statements           = <<-EOT # forces replacement
              - ALTER ACCOUNT SET TIMEZONE = 'UTC'
              + ALTER ACCOUNT SET TIMEZONE = 'MST'
            EOT
            # (1 unchanged attribute hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
snowsql_exec.use_utc_timezone_for_account: Destroying... [id=snowflake-timezone-parameter-utc]
snowsql_exec.use_utc_timezone_for_account: Destruction complete after 1s
snowsql_exec.use_utc_timezone_for_account: Creating...
snowsql_exec.use_utc_timezone_for_account: Creation complete after 0s [id=snowflake-timezone-parameter-utc]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```