### PR TITLE
docs: consolidated `snowsql_exec` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Terraform Provider SnowSQL
 
-The `snowsql` provider allows for the management of the `create`, `read`, `update`, and `delete` lifecycles for [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
+The `snowsql` provider allows for custom Terraform CRUD management of [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
 
 >**Note**:  This provider is not a drop in replacement for the robust resources implemented by [terraform-provider-snowflake](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs). For example, use the `snowflake_warehouse` resource if you need to create a virtual warehouse, Use this provider when you require fine grain control of [DCL](https://www.geeksforgeeks.org/sql-ddl-dql-dml-dcl-tcl-commands/) commands or to implement Snowflake objects that are unsupported by the Snowflake provider resources.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
 ---
 page_title: "Provider: SnowSQL"
 description: |-
-  The `snowsql` provider allows for the management of the `create`, `read`, `update`, and `delete` lifecycles for [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
+  The `snowsql` provider allows for custom Terraform CRUD management of [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
 ---
 
 # SnowSQL Provider
 
-The `snowsql` provider allows for the management of the `create`, `read`, `update`, and `delete` lifecycles for [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
+The `snowsql` provider allows for custom Terraform CRUD management of [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
 
 -> **NOTE:** This provider is not a drop in replacement This provider is not a drop in replacement for the robust resources implemented by [terraform-provider-snowflake](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs). For example, use the `snowflake_warehouse` resource if you need to create a virtual warehouse, Use this provider when you require fine grain control of [DCL](https://www.geeksforgeeks.org/sql-ddl-dql-dml-dcl-tcl-commands/) commands or to implement Snowflake objects that are unsupported by the Snowflake provider resources.
 

--- a/docs/resources/exec.md
+++ b/docs/resources/exec.md
@@ -33,9 +33,7 @@ resource "snowsql_exec" "role" {
 
 ### Query Snowflake With Read Statements
 
-The `snowsql_exec` resource allows you to execute arbitrary Snowflake SQL queries from Terraform, and use the results in your infrastructure management. When using the read statements in the resource, the result(s) of the SQL query/queries will be available in the `read_results` attribute as a sensitive raw JSON string. 
-
-To output the query results in a non-sensitive format to the console, you can use the `nonsensitive` function to mark the `read_results` value as non-sensitive before decoding it with the `jsondecode` function.
+This resource allows you to execute arbitrary SnowSQL queries and use the results in your infrastructure management.
 
 ```terraform
 resource "snowsql_exec" "role" {
@@ -83,7 +81,7 @@ show_role_results = [
 
 ### Avoiding Replacement With Update Lifecycle
 
-This example demonstrates the behavior of the `snowsql_exec` resource when using the optional update statements to modify an existing object. If the update statements are added or changed after the initial terraform apply, Terraform will perform an in-place change by executing the update statement(s). On the other hand, any changes to the create statements will cause a replacement of the resource.
+Execute the update statements as an in-place Terraform change by adding or modifying them after the initial Terraform apply. However, if there are any changes to the create statements, the resource will need to be replaced.
 
 1. The create statements are run on the first apply:
 
@@ -127,7 +125,7 @@ resource "snowsql_exec" "role" {
 
 ### Multi-Statements
 
-This resource allows you to execute multiple SnowSQL statements separated by semicolons. This is particularly useful for managing multiple Snowflake objects within a single `snowsql_exec` resource.
+This resource allows you to execute multiple SnowSQL statements separated by semicolons. This is particularly useful for managing multiple Snowflake objects within a single resource.
 
 ```terraform
 resource "snowflake_database" "database" {
@@ -249,13 +247,13 @@ resource "snowsql_exec" "function" {
 The nested blocks all have the same arguments.
 
 - `statements` (Required) A string containing one or many SnowSQL statements separated by semicolons.
-- `number_of_statements` (Optional) Specifies the number of SnowSQL statements. This can help reduce the risk of SQL injection attacks.
+- `number_of_statements` (Optional) The number of SnowSQL statements. This can help reduce the risk of SQL injection attacks.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-- `read_results` (String, Sensitive) The List of query results from the read statements.
+- `read_results` (String) The encoded JSON list of query results from the read statements. This value is always marked as sensitive.
 
 ## Import
 

--- a/docs/resources/exec.md
+++ b/docs/resources/exec.md
@@ -7,11 +7,11 @@ description: |-
 
 # snowsql_exec (Resource)
 
-The `snowsql_exec` resource allows for the management of the `create`, `read`, `update`, and `delete` lifecycles for [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
+The `snowsql_exec` resource allows for custom Terraform CRUD management of [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
 
 ## Examples
 
-This example shows how to `create` and `delete` a Snowflake role with the `snowsql_exec` resource.
+This basic example shows how to manage an arbitrary Snowflake object.
 
 ```terraform
 resource "snowsql_exec" "role" {
@@ -27,13 +27,13 @@ resource "snowsql_exec" "role" {
 }
 ```
 
--> **NOTE:** It is highly recommended to test all SnowSQL statements, especially `create` and `delete` statements, in a [Snowflake worksheet](https://docs.snowflake.com/en/user-guide/ui-worksheet) prior to executing them. This can help avoid any unexpected issues during the execution of these statements.
+-> **NOTE:** It is highly recommended to test all SnowSQL statements, especially create and delete statements, in a [Snowflake worksheet](https://docs.snowflake.com/en/user-guide/ui-worksheet) prior to executing them. This can help avoid any unexpected issues during the execution of these statements.
 
-~> **NOTE:** It is important to ensure that any `delete` statements negate any corresponding `create` statements, to avoid any orphaned Snowflake objects. Failure to do so can result in clutter and potential issues within your Snowflake environment.
+~> **NOTE:** It is important to ensure that any delete statements negate any corresponding create statements, to avoid any orphaned Snowflake objects. Failure to do so can result in clutter and potential issues within your Snowflake environment.
 
 ### Query Snowflake With Read Statements
 
-The `snowsql_exec` resource allows you to execute arbitrary Snowflake SQL queries from Terraform, and use the results in your infrastructure management. When using the `read` statements in the resource, the result(s) of the SQL query/queries will be available in the `read_results` attribute as a sensitive raw JSON string. 
+The `snowsql_exec` resource allows you to execute arbitrary Snowflake SQL queries from Terraform, and use the results in your infrastructure management. When using the read statements in the resource, the result(s) of the SQL query/queries will be available in the `read_results` attribute as a sensitive raw JSON string. 
 
 To output the query results in a non-sensitive format to the console, you can use the `nonsensitive` function to mark the `read_results` value as non-sensitive before decoding it with the `jsondecode` function.
 
@@ -83,9 +83,9 @@ show_role_results = [
 
 ### Avoiding Replacement With Update Lifecycle
 
-This example demonstrates the behavior of the `snowsql_exec` resource when using the optional `update` statements to modify an existing object. If the `update` statements are added or changed after the initial terraform apply, Terraform will perform an in-place change by executing the `update` statement(s). On the other hand, any changes to the `create` statements will cause a replacement of the resource.
+This example demonstrates the behavior of the `snowsql_exec` resource when using the optional update statements to modify an existing object. If the update statements are added or changed after the initial terraform apply, Terraform will perform an in-place change by executing the update statement(s). On the other hand, any changes to the create statements will cause a replacement of the resource.
 
-1. The `create` statements are run on the first apply:
+1. The create statements are run on the first apply:
 
 ```terraform
 resource "snowsql_exec" "role" {
@@ -105,7 +105,7 @@ resource "snowsql_exec" "role" {
 }
 ```
 
-2. Add the `update` statements to alter the role in-place.
+2. Add the update statements to alter the role in-place.
 
 ```terraform
 resource "snowsql_exec" "role" {
@@ -127,7 +127,7 @@ resource "snowsql_exec" "role" {
 
 ### Multi-Statements
 
-The `snowsql_exec` resource allows you to execute multiple SnowSQL statements separated by semicolons. This is particularly useful for managing multiple Snowflake objects within a single `snowsql_exec` resource.
+This resource allows you to execute multiple SnowSQL statements separated by semicolons. This is particularly useful for managing multiple Snowflake objects within a single `snowsql_exec` resource.
 
 ```terraform
 resource "snowflake_database" "database" {
@@ -194,7 +194,7 @@ resource "snowsql_exec" "role_grant_all" {
 
 ### Multi-line Statements
 
-All `snowsql_exec` resource statements can be formatted across multiple lines for better readability. This is particularly useful for executing complex SnowSQL statements.
+Statements can also be formatted across multiple lines for better readability. This is particularly useful for executing complex SnowSQL statements.
 
 ```terraform
 resource "snowsql_exec" "function" {
@@ -236,71 +236,26 @@ resource "snowsql_exec" "function" {
 }
 ```
 
-<!-- schema generated by tfplugindocs -->
-## Schema
+## Argument Reference
 
-### Required
+* `name` - (Required, Forces new resource) The name of the resource.
+* `create` - (Required, Forces new resource) Configuration block for create lifecycle statements. (see [below for nested schema](#nestedblock-lifecycle))
+* `read` - (Optional) Configuration block for read lifecycle statements. (see [below for nested schema](#nestedblock-lifecycle))
+* `update` - (Optional) Configuration block for in-place update lifecycle statements. (see [below for nested schema](###nestedblock-lifecycle))
+* `delete` - (Required) Configuration block for delete lifecycle statements. (see [below for nested schema](#nestedblock-lifecycle))
 
-- `create` (Block List, Min: 1, Max: 1) Specifies the SnowSQL create lifecycle. (see [below for nested schema](#nestedblock--create))
-- `delete` (Block List, Min: 1, Max: 1) Specifies the SnowSQL delete lifecycle. (see [below for nested schema](#nestedblock--delete))
-- `name` (String) Specifies the identifier for the SnowSQL resource.
+### Nested Blocks - `create`, `read`, `update`, and `delete`
 
-### Optional
+The nested blocks all have the same arguments.
 
-- `read` (Block List, Max: 1) Specifies the SnowSQL read lifecycle. (see [below for nested schema](#nestedblock--read))
-- `update` (Block List, Max: 1) Specifies the SnowSQL update lifecycle. (see [below for nested schema](#nestedblock--update))
+- `statements` (Required) A string containing one or many SnowSQL statements separated by semicolons.
+- `number_of_statements` (Optional) Specifies the number of SnowSQL statements. This can help reduce the risk of SQL injection attacks.
 
-### Read-Only
+## Attribute Reference
 
-- `id` (String) The ID of this resource.
+In addition to all arguments above, the following attributes are exported:
+
 - `read_results` (String, Sensitive) The List of query results from the read statements.
-
-<a id="nestedblock--create"></a>
-### Nested Schema for `create`
-
-Required:
-
-- `statements` (String) A string containing one or many SnowSQL statements separated by semicolons. This can help reduce the risk of SQL injection attacks.
-
-Optional:
-
-- `number_of_statements` (Number) A string containing one or many SnowSQL statements separated by semicolons. This can help reduce the risk of SQL injection attacks.
-
-
-<a id="nestedblock--delete"></a>
-### Nested Schema for `delete`
-
-Required:
-
-- `statements` (String) A string containing one or many SnowSQL statements separated by semicolons.
-
-Optional:
-
-- `number_of_statements` (Number) Specifies the number of SnowSQL statements. If not provided, the default value is the count of semicolons in SnowSQL statements.
-
-
-<a id="nestedblock--read"></a>
-### Nested Schema for `read`
-
-Required:
-
-- `statements` (String) A string containing one or many SnowSQL statements separated by semicolons.
-
-Optional:
-
-- `number_of_statements` (Number) Specifies the number of SnowSQL statements. If not provided, the default value is the count of semicolons in SnowSQL statements.
-
-
-<a id="nestedblock--update"></a>
-### Nested Schema for `update`
-
-Required:
-
-- `statements` (String) A string containing one or many SnowSQL statements separated by semicolons.
-
-Optional:
-
-- `number_of_statements` (Number) Specifies the number of SnowSQL statements. If not provided, the default value is the count of semicolons in SnowSQL statements.
 
 ## Import
 

--- a/docs/resources/exec.md
+++ b/docs/resources/exec.md
@@ -237,10 +237,10 @@ resource "snowsql_exec" "function" {
 ## Argument Reference
 
 * `name` - (Required, Forces new resource) The name of the resource.
-* `create` - (Required, Forces new resource) Configuration block for create lifecycle statements. (see [below for nested schema](#nestedblock-lifecycle))
-* `read` - (Optional) Configuration block for read lifecycle statements. (see [below for nested schema](#nestedblock-lifecycle))
-* `update` - (Optional) Configuration block for in-place update lifecycle statements. (see [below for nested schema](###nestedblock-lifecycle))
-* `delete` - (Required) Configuration block for delete lifecycle statements. (see [below for nested schema](#nestedblock-lifecycle))
+* `create` - (Required, Forces new resource) Configuration block for create lifecycle statements. (see [below for nested schema](#nested-blocks---create-read-update-and-delete))
+* `read` - (Optional) Configuration block for read lifecycle statements. (see [below for nested schema](#nested-blocks---create-read-update-and-delete))
+* `update` - (Optional) Configuration block for in-place update lifecycle statements. (see [below for nested schema](###nested-blocks---create-read-update-and-delete))
+* `delete` - (Required) Configuration block for delete lifecycle statements. (see [below for nested schema](#nested-blocks---create-read-update-and-delete))
 
 ### Nested Blocks - `create`, `read`, `update`, and `delete`
 

--- a/examples/resources/exec/complete/main.tf
+++ b/examples/resources/exec/complete/main.tf
@@ -54,4 +54,3 @@ resource "snowsql_exec" "role_grant_all" {
     EOT
   }
 }
-

--- a/snowsql/resource_exec.go
+++ b/snowsql/resource_exec.go
@@ -75,14 +75,14 @@ func resourceExec() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "Specifies the identifier for the SnowSQL resource.",
+				Description: "The name of the resource.",
 			},
 			"create": {
 				Type:        schema.TypeList,
 				Required:    true,
 				MaxItems:    1,
 				ForceNew:    true,
-				Description: "Specifies the SnowSQL create lifecycle.",
+				Description: "Configuration block for create lifecycle statements.",
 				Elem: &schema.Resource{
 					Schema: createLifecycleSchema,
 				},
@@ -92,7 +92,7 @@ func resourceExec() *schema.Resource {
 				Optional:    true,
 				MaxItems:    1,
 				ForceNew:    false,
-				Description: "Specifies the SnowSQL read lifecycle.",
+				Description: "Configuration block for read lifecycle statements.",
 				Elem: &schema.Resource{
 					Schema: lifecycleSchema,
 				},
@@ -102,7 +102,7 @@ func resourceExec() *schema.Resource {
 				Optional:    true,
 				MaxItems:    1,
 				ForceNew:    false,
-				Description: "Specifies the SnowSQL update lifecycle.",
+				Description: "Configuration block for update lifecycle statements.",
 				Elem: &schema.Resource{
 					Schema: lifecycleSchema,
 				},
@@ -112,7 +112,7 @@ func resourceExec() *schema.Resource {
 				Required:    true,
 				MaxItems:    1,
 				ForceNew:    false,
-				Description: "Specifies the SnowSQL delete lifecycle.",
+				Description: "Configuration block for delete lifecycle statements.",
 				Elem: &schema.Resource{
 					Schema: lifecycleSchema,
 				},

--- a/snowsql/resource_exec.go
+++ b/snowsql/resource_exec.go
@@ -15,7 +15,7 @@ import (
 	"github.com/snowflakedb/gosnowflake"
 )
 
-var numberOfStatementsDescription = "A string containing one or many SnowSQL statements separated by semicolons. This can help reduce the risk of SQL injection attacks."
+var numberOfStatementsDescription = "The number of SnowSQL statements. This can help reduce the risk of SQL injection attacks. Defaults to `null`."
 
 var createLifecycleSchema = map[string]*schema.Schema{
 	"statements": {
@@ -34,7 +34,6 @@ var createLifecycleSchema = map[string]*schema.Schema{
 	"number_of_statements": {
 		Type:        schema.TypeInt,
 		Optional:    true,
-		ForceNew:    true,
 		Default:     nil,
 		Computed:    true,
 		Description: numberOfStatementsDescription,
@@ -121,7 +120,7 @@ func resourceExec() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Sensitive:   true,
-				Description: "The List of query results from the read statements.",
+				Description: "The encoded JSON list of query results from the read statements. This value is always marked as sensitive.",
 			},
 		},
 		CustomizeDiff: customdiff.All(

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -1,12 +1,12 @@
 ---
 page_title: "Provider: SnowSQL"
 description: |-
-  The `snowsql` provider allows for the management of the `create`, `read`, `update`, and `delete` lifecycles for [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
+  The `snowsql` provider allows for custom Terraform CRUD management of [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
 ---
 
 # SnowSQL Provider
 
-The `snowsql` provider allows for the management of the `create`, `read`, `update`, and `delete` lifecycles for [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
+The `snowsql` provider allows for custom Terraform CRUD management of [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
 
 -> **NOTE:** This provider is not a drop in replacement This provider is not a drop in replacement for the robust resources implemented by [terraform-provider-snowflake](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs). For example, use the `snowflake_warehouse` resource if you need to create a virtual warehouse, Use this provider when you require fine grain control of [DCL](https://www.geeksforgeeks.org/sql-ddl-dql-dml-dcl-tcl-commands/) commands or to implement Snowflake objects that are unsupported by the Snowflake provider resources.
 

--- a/templates/resources/exec.md.tmpl
+++ b/templates/resources/exec.md.tmpl
@@ -77,10 +77,10 @@ Statements can also be formatted across multiple lines for better readability. T
 ## Argument Reference
 
 * `name` - (Required, Forces new resource) The name of the resource.
-* `create` - (Required, Forces new resource) Configuration block for create lifecycle statements. (see [below for nested schema](#nestedblock-lifecycle))
-* `read` - (Optional) Configuration block for read lifecycle statements. (see [below for nested schema](#nestedblock-lifecycle))
-* `update` - (Optional) Configuration block for in-place update lifecycle statements. (see [below for nested schema](###nestedblock-lifecycle))
-* `delete` - (Required) Configuration block for delete lifecycle statements. (see [below for nested schema](#nestedblock-lifecycle))
+* `create` - (Required, Forces new resource) Configuration block for create lifecycle statements. (see [below for nested schema](#nested-blocks---create-read-update-and-delete))
+* `read` - (Optional) Configuration block for read lifecycle statements. (see [below for nested schema](#nested-blocks---create-read-update-and-delete))
+* `update` - (Optional) Configuration block for in-place update lifecycle statements. (see [below for nested schema](###nested-blocks---create-read-update-and-delete))
+* `delete` - (Required) Configuration block for delete lifecycle statements. (see [below for nested schema](#nested-blocks---create-read-update-and-delete))
 
 ### Nested Blocks - `create`, `read`, `update`, and `delete`
 

--- a/templates/resources/exec.md.tmpl
+++ b/templates/resources/exec.md.tmpl
@@ -21,9 +21,7 @@ This basic example shows how to manage an arbitrary Snowflake object.
 
 ### Query Snowflake With Read Statements
 
-The `snowsql_exec` resource allows you to execute arbitrary Snowflake SQL queries from Terraform, and use the results in your infrastructure management. When using the read statements in the resource, the result(s) of the SQL query/queries will be available in the `read_results` attribute as a sensitive raw JSON string. 
-
-To output the query results in a non-sensitive format to the console, you can use the `nonsensitive` function to mark the `read_results` value as non-sensitive before decoding it with the `jsondecode` function.
+This resource allows you to execute arbitrary SnowSQL queries and use the results in your infrastructure management.
 
 {{ tffile "examples/resources/exec/basic/main.tf.read.example" }}
 
@@ -50,7 +48,7 @@ show_role_results = [
 
 ### Avoiding Replacement With Update Lifecycle
 
-This example demonstrates the behavior of the `snowsql_exec` resource when using the optional update statements to modify an existing object. If the update statements are added or changed after the initial terraform apply, Terraform will perform an in-place change by executing the update statement(s). On the other hand, any changes to the create statements will cause a replacement of the resource.
+Execute the update statements as an in-place Terraform change by adding or modifying them after the initial Terraform apply. However, if there are any changes to the create statements, the resource will need to be replaced.
 
 1. The create statements are run on the first apply:
 
@@ -62,7 +60,7 @@ This example demonstrates the behavior of the `snowsql_exec` resource when using
 
 ### Multi-Statements
 
-This resource allows you to execute multiple SnowSQL statements separated by semicolons. This is particularly useful for managing multiple Snowflake objects within a single `snowsql_exec` resource.
+This resource allows you to execute multiple SnowSQL statements separated by semicolons. This is particularly useful for managing multiple Snowflake objects within a single resource.
 
 {{ tffile "examples/resources/exec/complete/main.tf" }}
 
@@ -89,13 +87,13 @@ Statements can also be formatted across multiple lines for better readability. T
 The nested blocks all have the same arguments.
 
 - `statements` (Required) A string containing one or many SnowSQL statements separated by semicolons.
-- `number_of_statements` (Optional) Specifies the number of SnowSQL statements. This can help reduce the risk of SQL injection attacks.
+- `number_of_statements` (Optional) The number of SnowSQL statements. This can help reduce the risk of SQL injection attacks.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-- `read_results` (String, Sensitive) The List of query results from the read statements.
+- `read_results` (String) The encoded JSON list of query results from the read statements. This value is always marked as sensitive.
 
 ## Import
 

--- a/templates/resources/exec.md.tmpl
+++ b/templates/resources/exec.md.tmpl
@@ -7,21 +7,21 @@ description: |-
 
 # {{.Name}} ({{.Type}})
 
-The `snowsql_exec` resource allows for the management of the `create`, `read`, `update`, and `delete` lifecycles for [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
+The `snowsql_exec` resource allows for custom Terraform CRUD management of [Snowflake](https://www.snowflake.com) objects using [SnowSQL](https://docs.snowflake.com/en/user-guide/snowsql.html).
 
 ## Examples
 
-This example shows how to `create` and `delete` a Snowflake role with the `snowsql_exec` resource.
+This basic example shows how to manage an arbitrary Snowflake object.
 
 {{ tffile "examples/resources/exec/basic/main.tf.create-delete.example" }}
 
--> **NOTE:** It is highly recommended to test all SnowSQL statements, especially `create` and `delete` statements, in a [Snowflake worksheet](https://docs.snowflake.com/en/user-guide/ui-worksheet) prior to executing them. This can help avoid any unexpected issues during the execution of these statements.
+-> **NOTE:** It is highly recommended to test all SnowSQL statements, especially create and delete statements, in a [Snowflake worksheet](https://docs.snowflake.com/en/user-guide/ui-worksheet) prior to executing them. This can help avoid any unexpected issues during the execution of these statements.
 
-~> **NOTE:** It is important to ensure that any `delete` statements negate any corresponding `create` statements, to avoid any orphaned Snowflake objects. Failure to do so can result in clutter and potential issues within your Snowflake environment.
+~> **NOTE:** It is important to ensure that any delete statements negate any corresponding create statements, to avoid any orphaned Snowflake objects. Failure to do so can result in clutter and potential issues within your Snowflake environment.
 
 ### Query Snowflake With Read Statements
 
-The `snowsql_exec` resource allows you to execute arbitrary Snowflake SQL queries from Terraform, and use the results in your infrastructure management. When using the `read` statements in the resource, the result(s) of the SQL query/queries will be available in the `read_results` attribute as a sensitive raw JSON string. 
+The `snowsql_exec` resource allows you to execute arbitrary Snowflake SQL queries from Terraform, and use the results in your infrastructure management. When using the read statements in the resource, the result(s) of the SQL query/queries will be available in the `read_results` attribute as a sensitive raw JSON string. 
 
 To output the query results in a non-sensitive format to the console, you can use the `nonsensitive` function to mark the `read_results` value as non-sensitive before decoding it with the `jsondecode` function.
 
@@ -50,19 +50,19 @@ show_role_results = [
 
 ### Avoiding Replacement With Update Lifecycle
 
-This example demonstrates the behavior of the `snowsql_exec` resource when using the optional `update` statements to modify an existing object. If the `update` statements are added or changed after the initial terraform apply, Terraform will perform an in-place change by executing the `update` statement(s). On the other hand, any changes to the `create` statements will cause a replacement of the resource.
+This example demonstrates the behavior of the `snowsql_exec` resource when using the optional update statements to modify an existing object. If the update statements are added or changed after the initial terraform apply, Terraform will perform an in-place change by executing the update statement(s). On the other hand, any changes to the create statements will cause a replacement of the resource.
 
-1. The `create` statements are run on the first apply:
+1. The create statements are run on the first apply:
 
 {{ tffile "examples/resources/exec/basic/main.tf" }}
 
-2. Add the `update` statements to alter the role in-place.
+2. Add the update statements to alter the role in-place.
 
 {{ tffile "examples/resources/exec/basic/main.tf.update.example" }}
 
 ### Multi-Statements
 
-The `snowsql_exec` resource allows you to execute multiple SnowSQL statements separated by semicolons. This is particularly useful for managing multiple Snowflake objects within a single `snowsql_exec` resource.
+This resource allows you to execute multiple SnowSQL statements separated by semicolons. This is particularly useful for managing multiple Snowflake objects within a single `snowsql_exec` resource.
 
 {{ tffile "examples/resources/exec/complete/main.tf" }}
 
@@ -72,11 +72,30 @@ The `snowsql_exec` resource allows you to execute multiple SnowSQL statements se
 
 ### Multi-line Statements
 
-All `snowsql_exec` resource statements can be formatted across multiple lines for better readability. This is particularly useful for executing complex SnowSQL statements.
+Statements can also be formatted across multiple lines for better readability. This is particularly useful for executing complex SnowSQL statements.
 
 {{ tffile "examples/resources/exec/complete/function.tf" }}
 
-{{ .SchemaMarkdown | trimspace }}
+## Argument Reference
+
+* `name` - (Required, Forces new resource) The name of the resource.
+* `create` - (Required, Forces new resource) Configuration block for create lifecycle statements. (see [below for nested schema](#nestedblock-lifecycle))
+* `read` - (Optional) Configuration block for read lifecycle statements. (see [below for nested schema](#nestedblock-lifecycle))
+* `update` - (Optional) Configuration block for in-place update lifecycle statements. (see [below for nested schema](###nestedblock-lifecycle))
+* `delete` - (Required) Configuration block for delete lifecycle statements. (see [below for nested schema](#nestedblock-lifecycle))
+
+### Nested Blocks - `create`, `read`, `update`, and `delete`
+
+The nested blocks all have the same arguments.
+
+- `statements` (Required) A string containing one or many SnowSQL statements separated by semicolons.
+- `number_of_statements` (Optional) Specifies the number of SnowSQL statements. This can help reduce the risk of SQL injection attacks.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `read_results` (String, Sensitive) The List of query results from the read statements.
 
 ## Import
 


### PR DESCRIPTION
consolidated schema docs. we are no longer generating this portion of the docs with `tfplugindocs` mainly because this provider by its natural will have very few resources and due to the similarities of the create, read, update, and delete schema it makes sense to simplify the docs into a single nested-block definition similar to https://github.com/hashicorp/terraform-provider-aws/blob/main/website/docs/r/default_security_group.html.markdown\#egress-and-ingress