### PR TITLE
Fix read number of statements

### DIFF
--- a/docs/resources/exec.md
+++ b/docs/resources/exec.md
@@ -94,7 +94,7 @@ resource "snowsql_exec" "role" {
   }
 
   read {
-    statements = "SHOW ROLES LIKE 'my_role';"
+    statements = "SHOW ROLES LIKE 'my_role'"
   }
 
   delete {
@@ -250,7 +250,7 @@ resource "snowsql_exec" "function" {
 The nested blocks all have the same arguments.
 
 - `statements` (Required) A string containing one or many SnowSQL statements separated by semicolons.
-- `number_of_statements` (Optional) The number of SnowSQL statements to be executed. This can help reduce the risk of SQL injection attacks. Defaults to `null` indicating that there is no limit on the number of statements. `0` and `-1` also indicate no limit.
+- `number_of_statements` (Optional) The number of SnowSQL statements to be executed. This can help reduce the risk of SQL injection attacks. Defaults to `null` indicating that there is no limit on the number of statements (`0` and `-1` also indicate no limit).
 
 ## Attribute Reference
 

--- a/docs/resources/exec.md
+++ b/docs/resources/exec.md
@@ -94,7 +94,7 @@ resource "snowsql_exec" "role" {
   }
 
   read {
-    statements = "SHOW ROLES LIKE 'my_role'"
+    statements = "SHOW ROLES LIKE 'my_role';"
   }
 
   delete {
@@ -250,7 +250,7 @@ resource "snowsql_exec" "function" {
 The nested blocks all have the same arguments.
 
 - `statements` (Required) A string containing one or many SnowSQL statements separated by semicolons.
-- `number_of_statements` (Optional) The number of SnowSQL statements. This can help reduce the risk of SQL injection attacks. Defaults to `null`.
+- `number_of_statements` (Optional) The number of SnowSQL statements to be executed. This can help reduce the risk of SQL injection attacks. Defaults to `null` indicating that there is no limit on the number of statements. `0` and `-1` also indicate no limit.
 
 ## Attribute Reference
 

--- a/docs/resources/exec.md
+++ b/docs/resources/exec.md
@@ -156,6 +156,7 @@ resource "snowsql_exec" "role_grant_all" {
       GRANT ALL PRIVILEGES ON FUTURE STREAMS IN DATABASE ${snowflake_database.database.name} TO ROLE ${snowflake_role.role.name};
       GRANT ALL PRIVILEGES ON FUTURE PROCEDURES IN DATABASE ${snowflake_database.database.name} TO ROLE ${snowflake_role.role.name};
     EOT
+    number_of_statements = 14
   }
 
   read {
@@ -163,6 +164,7 @@ resource "snowsql_exec" "role_grant_all" {
       SHOW GRANTS TO ROLE ${local.name};
       SHOW FUTURE GRANTS TO ROLE ${local.name};
     EOT
+    number_of_statements = 2
   }
 
   delete {
@@ -182,6 +184,7 @@ resource "snowsql_exec" "role_grant_all" {
       REVOKE ALL PRIVILEGES ON FUTURE STREAMS IN DATABASE ${snowflake_database.database.name} FROM ROLE ${snowflake_role.role.name};
       REVOKE ALL PRIVILEGES ON FUTURE PROCEDURES IN DATABASE ${snowflake_database.database.name} FROM ROLE ${snowflake_role.role.name};
     EOT
+    number_of_statements = 14
   }
 }
 ```
@@ -247,7 +250,7 @@ resource "snowsql_exec" "function" {
 The nested blocks all have the same arguments.
 
 - `statements` (Required) A string containing one or many SnowSQL statements separated by semicolons.
-- `number_of_statements` (Optional) The number of SnowSQL statements. This can help reduce the risk of SQL injection attacks.
+- `number_of_statements` (Optional) The number of SnowSQL statements. This can help reduce the risk of SQL injection attacks. Defaults to `null`.
 
 ## Attribute Reference
 

--- a/examples/resources/exec/basic/main.tf
+++ b/examples/resources/exec/basic/main.tf
@@ -7,7 +7,6 @@ resource "snowsql_exec" "role" {
 
   read {
     statements = "SHOW ROLES LIKE 'my_role'"
-    number_of_statements = 1
   }
 
   delete {

--- a/examples/resources/exec/basic/main.tf
+++ b/examples/resources/exec/basic/main.tf
@@ -2,11 +2,15 @@ resource "snowsql_exec" "role" {
   name = "my_role"
 
   create {
-    statements = "CREATE ROLE IF NOT EXISTS my_role"
+    statements = "CREATE ROLE IF NOT EXISTS my_role;"
   }
 
   read {
-    statements = "SHOW ROLES LIKE 'my_role'"
+    statements = "SHOW ROLES LIKE 'SYSADMIN';\nSHOW ROLES LIKE 'ACCOUNTADMIN';"
+    # statements = <<-EOF
+    #   SHOW ROLES LIKE 'ACCOUNTADMIN';
+    #   SHOW ROLES LIKE 'my_role';
+    # EOF
   }
 
   delete {

--- a/examples/resources/exec/basic/main.tf
+++ b/examples/resources/exec/basic/main.tf
@@ -2,15 +2,12 @@ resource "snowsql_exec" "role" {
   name = "my_role"
 
   create {
-    statements = "CREATE ROLE IF NOT EXISTS my_role;"
+    statements = "CREATE ROLE IF NOT EXISTS my_role"
   }
 
   read {
-    statements = "SHOW ROLES LIKE 'SYSADMIN';\nSHOW ROLES LIKE 'ACCOUNTADMIN';"
-    # statements = <<-EOF
-    #   SHOW ROLES LIKE 'ACCOUNTADMIN';
-    #   SHOW ROLES LIKE 'my_role';
-    # EOF
+    statements = "SHOW ROLES LIKE 'my_role'"
+    number_of_statements = 1
   }
 
   delete {

--- a/examples/resources/exec/basic/main.tf
+++ b/examples/resources/exec/basic/main.tf
@@ -6,7 +6,7 @@ resource "snowsql_exec" "role" {
   }
 
   read {
-    statements = "SHOW ROLES LIKE 'my_role';"
+    statements = "SHOW ROLES LIKE 'my_role'"
   }
 
   delete {

--- a/examples/resources/exec/basic/main.tf
+++ b/examples/resources/exec/basic/main.tf
@@ -6,7 +6,7 @@ resource "snowsql_exec" "role" {
   }
 
   read {
-    statements = "SHOW ROLES LIKE 'my_role'"
+    statements = "SHOW ROLES LIKE 'my_role';"
   }
 
   delete {

--- a/examples/resources/exec/complete/main.tf
+++ b/examples/resources/exec/complete/main.tf
@@ -26,6 +26,7 @@ resource "snowsql_exec" "role_grant_all" {
       GRANT ALL PRIVILEGES ON FUTURE STREAMS IN DATABASE ${snowflake_database.database.name} TO ROLE ${snowflake_role.role.name};
       GRANT ALL PRIVILEGES ON FUTURE PROCEDURES IN DATABASE ${snowflake_database.database.name} TO ROLE ${snowflake_role.role.name};
     EOT
+    number_of_statements = 14
   }
 
   read {
@@ -33,6 +34,7 @@ resource "snowsql_exec" "role_grant_all" {
       SHOW GRANTS TO ROLE ${local.name};
       SHOW FUTURE GRANTS TO ROLE ${local.name};
     EOT
+    number_of_statements = 2
   }
 
   delete {
@@ -52,5 +54,6 @@ resource "snowsql_exec" "role_grant_all" {
       REVOKE ALL PRIVILEGES ON FUTURE STREAMS IN DATABASE ${snowflake_database.database.name} FROM ROLE ${snowflake_role.role.name};
       REVOKE ALL PRIVILEGES ON FUTURE PROCEDURES IN DATABASE ${snowflake_database.database.name} FROM ROLE ${snowflake_role.role.name};
     EOT
+    number_of_statements = 14
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Snowflake-Labs/terraform-provider-snowflake v0.54.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/jmoiron/sqlx v1.3.5
+	github.com/pkg/errors v0.9.1
 	github.com/snowflakedb/gosnowflake v1.6.16
 )
 

--- a/snowsql/resource_exec.go
+++ b/snowsql/resource_exec.go
@@ -59,7 +59,7 @@ var lifecycleSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Default:     nil,
 		Computed:    true,
-		Description: "Specifies the number of SnowSQL statements. If not provided, the default value is the count of semicolons in SnowSQL statements.",
+		Description: numberOfStatementsDescription,
 	},
 }
 
@@ -137,12 +137,7 @@ func resourceExec() *schema.Resource {
 func parseLifecycleSchemaData(lifecycle string, d *schema.ResourceData) (string, int) {
 	l := d.Get(lifecycle).([]interface{})
 	multiStmt := l[0].(map[string]interface{})["statements"].(string)
-	numOfStmts, ok := l[0].(map[string]interface{})["number_of_statements"].(int)
-
-	if !ok {
-		numOfStmts = strings.Count(multiStmt, ";")
-	}
-
+	numOfStmts := l[0].(map[string]interface{})["number_of_statements"].(int)
 	return multiStmt, numOfStmts
 }
 

--- a/snowsql/resource_exec.go
+++ b/snowsql/resource_exec.go
@@ -13,7 +13,7 @@ import (
 	"github.com/snowflakedb/gosnowflake"
 )
 
-var numberOfStatementsDescription = "The number of SnowSQL statements to be executed. This can help reduce the risk of SQL injection attacks. Defaults to `null` indicating that there is no limit on the number of statements. `0` and `-1` also indicate no limit."
+var numberOfStatementsDescription = "The number of SnowSQL statements to be executed. This can help reduce the risk of SQL injection attacks. Defaults to `null` indicating that there is no limit on the number of statements (`0` and `-1` also indicate no limit)."
 
 var createLifecycleSchema = map[string]*schema.Schema{
 	"statements": {

--- a/snowsql/resource_exec_acceptance_test.go
+++ b/snowsql/resource_exec_acceptance_test.go
@@ -19,21 +19,21 @@ func TestAccLifecycles(t *testing.T) {
 				Config: applyCreate(accName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowsql_exec.role", "name", accName),
-					resource.TestCheckResourceAttr("snowsql_exec.role", "create.0.statements", fmt.Sprintf("CREATE ROLE IF NOT EXISTS %s;", accName)),
+					resource.TestCheckResourceAttr("snowsql_exec.role", "create.0.statements", fmt.Sprintf("CREATE ROLE IF NOT EXISTS %s", accName)),
 					resource.TestCheckResourceAttr("snowsql_exec.role", "read.%", "0"),
 					resource.TestCheckResourceAttr("snowsql_exec.role", "update.%", "0"),
-					resource.TestCheckResourceAttr("snowsql_exec.role", "delete.0.statements", fmt.Sprintf("DROP ROLE IF EXISTS %s;", accName)),
-					resource.TestCheckResourceAttr("snowsql_exec.role", "read_results", "null"),
+					resource.TestCheckResourceAttr("snowsql_exec.role", "delete.0.statements", fmt.Sprintf("DROP ROLE IF EXISTS %s", accName)),
+					resource.TestCheckResourceAttr("snowsql_exec.role", "read_results", ""),
 				),
 			},
 			{
 				Config: applyOptionalLifecycleBlocks(accName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowsql_exec.role", "name", accName),
-					resource.TestCheckResourceAttr("snowsql_exec.role", "create.0.statements", fmt.Sprintf("CREATE ROLE IF NOT EXISTS %s;", accName)),
-					resource.TestCheckResourceAttr("snowsql_exec.role", "read.0.statements", fmt.Sprintf("SHOW ROLES LIKE '%s';", accName)),
-					resource.TestCheckResourceAttr("snowsql_exec.role", "update.0.statements", fmt.Sprintf("ALTER ROLE IF EXISTS %s SET COMMENT = 'updated with terraform';", accName)),
-					resource.TestCheckResourceAttr("snowsql_exec.role", "delete.0.statements", fmt.Sprintf("DROP ROLE IF EXISTS %s;", accName)),
+					resource.TestCheckResourceAttr("snowsql_exec.role", "create.0.statements", fmt.Sprintf("CREATE ROLE IF NOT EXISTS %s", accName)),
+					resource.TestCheckResourceAttr("snowsql_exec.role", "read.0.statements", fmt.Sprintf("SHOW ROLES LIKE '%s'", accName)),
+					resource.TestCheckResourceAttr("snowsql_exec.role", "update.0.statements", fmt.Sprintf("ALTER ROLE IF EXISTS %s SET COMMENT = 'updated with terraform'", accName)),
+					resource.TestCheckResourceAttr("snowsql_exec.role", "delete.0.statements", fmt.Sprintf("DROP ROLE IF EXISTS %s", accName)),
 					resource.TestCheckResourceAttrSet("snowsql_exec.role", "read_results"),
 				),
 			},
@@ -41,11 +41,11 @@ func TestAccLifecycles(t *testing.T) {
 				Config: destroyOptionalLifecycleBlocks(accName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowsql_exec.role", "name", accName),
-					resource.TestCheckResourceAttr("snowsql_exec.role", "create.0.statements", fmt.Sprintf("CREATE ROLE IF NOT EXISTS %s;", accName)),
+					resource.TestCheckResourceAttr("snowsql_exec.role", "create.0.statements", fmt.Sprintf("CREATE ROLE IF NOT EXISTS %s", accName)),
 					resource.TestCheckResourceAttr("snowsql_exec.role", "read.%", "0"),
 					resource.TestCheckResourceAttr("snowsql_exec.role", "update.%", "0"),
-					resource.TestCheckResourceAttr("snowsql_exec.role", "delete.0.statements", fmt.Sprintf("DROP ROLE IF EXISTS %s;", accName)),
-					resource.TestCheckResourceAttr("snowsql_exec.role", "read_results", "null"),
+					resource.TestCheckResourceAttr("snowsql_exec.role", "delete.0.statements", fmt.Sprintf("DROP ROLE IF EXISTS %s", accName)),
+					resource.TestCheckResourceAttr("snowsql_exec.role", "read_results", ""),
 				),
 			},
 		},
@@ -58,11 +58,11 @@ func applyCreate(name string) string {
 	  name = "%s"
 
 		create {
-			statements = "CREATE ROLE IF NOT EXISTS %s;"
+			statements = "CREATE ROLE IF NOT EXISTS %s"
 		}
 
 		delete {
-			statements = "DROP ROLE IF EXISTS %s;"
+			statements = "DROP ROLE IF EXISTS %s"
 		}
 	}
 	`
@@ -75,19 +75,19 @@ func applyOptionalLifecycleBlocks(name string) string {
 	  name = "%s"
 
 		create {
-			statements = "CREATE ROLE IF NOT EXISTS %s;"
+			statements = "CREATE ROLE IF NOT EXISTS %s"
 		}
 
 		read {
-			statements = "SHOW ROLES LIKE '%s';"
+			statements = "SHOW ROLES LIKE '%s'"
 		}
 
 		update {
-		  	statements = "ALTER ROLE IF EXISTS %s SET COMMENT = 'updated with terraform';"
+		  	statements = "ALTER ROLE IF EXISTS %s SET COMMENT = 'updated with terraform'"
 		}
 
 		delete {
-			statements = "DROP ROLE IF EXISTS %s;"
+			statements = "DROP ROLE IF EXISTS %s"
 		}
 	}
 	`
@@ -100,11 +100,11 @@ func destroyOptionalLifecycleBlocks(name string) string {
 	  name = "%s"
 
 		create {
-			statements = "CREATE ROLE IF NOT EXISTS %s;"
+			statements = "CREATE ROLE IF NOT EXISTS %s"
 		}
 
 		delete {
-			statements = "DROP ROLE IF EXISTS %s;"
+			statements = "DROP ROLE IF EXISTS %s"
 		}
 	}
 	`
@@ -121,10 +121,10 @@ func TestAccRead(t *testing.T) {
 				Config: readLifecycleBlockWithMultipleStatements(accName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowsql_exec.role", "name", accName),
-					resource.TestCheckResourceAttr("snowsql_exec.role", "create.0.statements", fmt.Sprintf("CREATE ROLE IF NOT EXISTS %s;", accName)),
+					resource.TestCheckResourceAttr("snowsql_exec.role", "create.0.statements", fmt.Sprintf("CREATE ROLE IF NOT EXISTS %s", accName)),
 					resource.TestCheckResourceAttr("snowsql_exec.role", "read.0.statements", fmt.Sprintf("SHOW ROLES LIKE '%s';\nSHOW ROLES \n\tLIKE 'SYSADMIN';\n", accName)),
 					resource.TestCheckResourceAttr("snowsql_exec.role", "update.%", "0"),
-					resource.TestCheckResourceAttr("snowsql_exec.role", "delete.0.statements", fmt.Sprintf("DROP ROLE IF EXISTS %s;", accName)),
+					resource.TestCheckResourceAttr("snowsql_exec.role", "delete.0.statements", fmt.Sprintf("DROP ROLE IF EXISTS %s", accName)),
 					resource.TestCheckResourceAttrSet("snowsql_exec.role", "read_results"),
 				),
 			},
@@ -138,7 +138,7 @@ func readLifecycleBlockWithMultipleStatements(name string) string {
 	  name = "%s"
 
 		create {
-			statements = "CREATE ROLE IF NOT EXISTS %s;"
+			statements = "CREATE ROLE IF NOT EXISTS %s"
 		}
 
 		read {
@@ -150,7 +150,7 @@ func readLifecycleBlockWithMultipleStatements(name string) string {
 		}
 
 		delete {
-			statements = "DROP ROLE IF EXISTS %s;"
+			statements = "DROP ROLE IF EXISTS %s"
 		}
 	}
 	`

--- a/templates/resources/exec.md.tmpl
+++ b/templates/resources/exec.md.tmpl
@@ -87,7 +87,7 @@ Statements can also be formatted across multiple lines for better readability. T
 The nested blocks all have the same arguments.
 
 - `statements` (Required) A string containing one or many SnowSQL statements separated by semicolons.
-- `number_of_statements` (Optional) The number of SnowSQL statements to be executed. This can help reduce the risk of SQL injection attacks. Defaults to `null` indicating that there is no limit on the number of statements. `0` and `-1` also indicate no limit.
+- `number_of_statements` (Optional) The number of SnowSQL statements to be executed. This can help reduce the risk of SQL injection attacks. Defaults to `null` indicating that there is no limit on the number of statements (`0` and `-1` also indicate no limit).
 
 ## Attribute Reference
 

--- a/templates/resources/exec.md.tmpl
+++ b/templates/resources/exec.md.tmpl
@@ -87,7 +87,7 @@ Statements can also be formatted across multiple lines for better readability. T
 The nested blocks all have the same arguments.
 
 - `statements` (Required) A string containing one or many SnowSQL statements separated by semicolons.
-- `number_of_statements` (Optional) The number of SnowSQL statements. This can help reduce the risk of SQL injection attacks. Defaults to `null`.
+- `number_of_statements` (Optional) The number of SnowSQL statements to be executed. This can help reduce the risk of SQL injection attacks. Defaults to `null` indicating that there is no limit on the number of statements. `0` and `-1` also indicate no limit.
 
 ## Attribute Reference
 

--- a/templates/resources/exec.md.tmpl
+++ b/templates/resources/exec.md.tmpl
@@ -87,7 +87,7 @@ Statements can also be formatted across multiple lines for better readability. T
 The nested blocks all have the same arguments.
 
 - `statements` (Required) A string containing one or many SnowSQL statements separated by semicolons.
-- `number_of_statements` (Optional) The number of SnowSQL statements. This can help reduce the risk of SQL injection attacks.
+- `number_of_statements` (Optional) The number of SnowSQL statements. This can help reduce the risk of SQL injection attacks. Defaults to `null`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
# Fixes
- #75 
- #78

# Changes
- Using a custom `ConfigureProvider` function because the [terraform-snowflake-provider](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/pkg/provider/provider.go#L352) doesn't work with QueryContext with multiple queries. Please see https://github.com/luna-duclos/instrumentedsql/issues/48 for more information.
- Removed the `parseLifecycleSchemaData` because it was causing problems across required and optional lifecycles.