### PR TITLE
feat(81): make name optional and default to random id when not set.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ REGISTRY=registry.terraform.io
 HOSTNAME=aidanmelen
 NAME=snowsql
 BINARY=terraform-provider-${NAME}
-VERSION=1.3.0
+VERSION=1.3.1
 OS_ARCH=darwin_amd64
 
 .PHONY: help

--- a/docs/resources/exec.md
+++ b/docs/resources/exec.md
@@ -15,8 +15,6 @@ This basic example shows how to manage an arbitrary Snowflake object.
 
 ```terraform
 resource "snowsql_exec" "role" {
-  name = "my_role"
-
   create {
     statements = "CREATE ROLE IF NOT EXISTS my_role"
   }
@@ -39,8 +37,6 @@ This resource allows you to execute arbitrary SnowSQL queries and use the result
 
 ```terraform
 resource "snowsql_exec" "role" {
-  name = "my_role"
-
   create {
     statements = "CREATE ROLE IF NOT EXISTS my_role"
   }
@@ -114,10 +110,8 @@ resource "snowsql_exec" "role" {
 
 ```terraform
 resource "snowsql_exec" "role" {
-  name = local.name
-
   create {
-    statements = "CREATE ROLE IF NOT EXISTS ${local.name}"
+    statements = "CREATE ROLE IF NOT EXISTS my_role"
   }
 
   read {
@@ -125,11 +119,11 @@ resource "snowsql_exec" "role" {
   }
 
   update {
-    statements = "ALTER ROLE IF EXISTS ${local.name} SET COMMENT = 'updated with terraform'"
+    statements = "ALTER ROLE IF EXISTS my_role SET COMMENT = 'updated with terraform'"
   }
 
   delete {
-    statements = "DROP ROLE IF EXISTS ${local.name}"
+    statements = "DROP ROLE IF EXISTS my_role"
   }
 }
 ```
@@ -254,7 +248,7 @@ resource "snowsql_exec" "function" {
 
 ## Argument Reference
 
-* `name` - (Required, Forces new resource) The name of the resource.
+* `name` - (Optional) The name of the resource. Defaults to random ID.
 * `create` - (Required, Forces new resource) Configuration block for create lifecycle statements. (see [below for nested schema](#nested-blocks---create-read-update-and-delete))
 * `read` - (Optional) Configuration block for read lifecycle statements. (see [below for nested schema](#nested-blocks---create-read-update-and-delete))
 * `update` - (Optional) Configuration block for in-place update lifecycle statements. (see [below for nested schema](###nested-blocks---create-read-update-and-delete))

--- a/docs/resources/exec.md
+++ b/docs/resources/exec.md
@@ -85,8 +85,6 @@ Execute the update statements as an in-place Terraform change by adding or modif
 
 ```terraform
 resource "snowsql_exec" "role" {
-  name = "my_role"
-
   create {
     statements = "CREATE ROLE IF NOT EXISTS my_role"
   }

--- a/examples/data-sources/query/provider.tf
+++ b/examples/data-sources/query/provider.tf
@@ -8,7 +8,7 @@ terraform {
     }
     snowsql = {
       source  = "aidanmelen/snowsql"
-      version = ">= 1.2.0"
+      version = ">= 1.3.1"
     }
     random = ">= 2.1"
   }

--- a/examples/resources/exec/basic/.create-delete.tf.docs
+++ b/examples/resources/exec/basic/.create-delete.tf.docs
@@ -1,6 +1,4 @@
 resource "snowsql_exec" "role" {
-  name = "my_role"
-
   create {
     statements = "CREATE ROLE IF NOT EXISTS my_role"
   }

--- a/examples/resources/exec/basic/.read.tf.docs
+++ b/examples/resources/exec/basic/.read.tf.docs
@@ -1,6 +1,4 @@
 resource "snowsql_exec" "role" {
-  name = "my_role"
-
   create {
     statements = "CREATE ROLE IF NOT EXISTS my_role"
   }

--- a/examples/resources/exec/basic/.update.tf.docs
+++ b/examples/resources/exec/basic/.update.tf.docs
@@ -1,8 +1,6 @@
 resource "snowsql_exec" "role" {
-  name = local.name
-
   create {
-    statements = "CREATE ROLE IF NOT EXISTS ${local.name}"
+    statements = "CREATE ROLE IF NOT EXISTS my_role"
   }
 
   read {
@@ -10,10 +8,10 @@ resource "snowsql_exec" "role" {
   }
 
   update {
-    statements = "ALTER ROLE IF EXISTS ${local.name} SET COMMENT = 'updated with terraform'"
+    statements = "ALTER ROLE IF EXISTS my_role SET COMMENT = 'updated with terraform'"
   }
 
   delete {
-    statements = "DROP ROLE IF EXISTS ${local.name}"
+    statements = "DROP ROLE IF EXISTS my_role"
   }
 }

--- a/examples/resources/exec/basic/main.tf
+++ b/examples/resources/exec/basic/main.tf
@@ -1,6 +1,4 @@
 resource "snowsql_exec" "role" {
-  name = "my_role"
-
   create {
     statements = "CREATE ROLE IF NOT EXISTS my_role"
   }

--- a/examples/resources/exec/basic/provider.tf
+++ b/examples/resources/exec/basic/provider.tf
@@ -8,7 +8,7 @@ terraform {
     }
     snowsql = {
       source  = "aidanmelen/snowsql"
-      version = ">= 1.2.0"
+      version = ">= 1.3.1"
     }
     random = ">= 2.1"
   }

--- a/examples/resources/exec/complete/README.md
+++ b/examples/resources/exec/complete/README.md
@@ -30,7 +30,7 @@ Note that this example may create resources which can cost money (Warehouse, Dat
 |------|---------|
 | <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 | <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | 0.56.3 |
-| <a name="provider_snowsql"></a> [snowsql](#provider\_snowsql) | 1.2.0 |
+| <a name="provider_snowsql"></a> [snowsql](#provider\_snowsql) | 1.3.1 |
 
 ## Modules
 

--- a/examples/resources/exec/complete/README.md
+++ b/examples/resources/exec/complete/README.md
@@ -30,7 +30,7 @@ Note that this example may create resources which can cost money (Warehouse, Dat
 |------|---------|
 | <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 | <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | 0.56.3 |
-| <a name="provider_snowsql"></a> [snowsql](#provider\_snowsql) | 1.3.1 |
+| <a name="provider_snowsql"></a> [snowsql](#provider\_snowsql) | 1.2.0 |
 
 ## Modules
 

--- a/examples/resources/exec/complete/provider.tf
+++ b/examples/resources/exec/complete/provider.tf
@@ -8,7 +8,7 @@ terraform {
     }
     snowsql = {
       source  = "aidanmelen/snowsql"
-      version = ">= 1.2.0"
+      version = ">= 1.3.1"
     }
     random = ">= 2.1"
   }

--- a/snowsql/resource_exec.go
+++ b/snowsql/resource_exec.go
@@ -156,7 +156,7 @@ func resourceExecCreate(ctx context.Context, d *schema.ResourceData, m interface
 	if ok {
 		ignore_update_stmts_warning := diag.Diagnostic{
 			Severity: diag.Warning,
-			Summary:  fmt.Sprintf("The update statements are ignored during resource creation:\n\nStatements:\n\n  %s", updateStmts.(string)),
+			Summary:  fmt.Sprintf("The update statements are ignored during resource creation and will not be executed until they are changed:\n\nStatements:\n\n  %s", updateStmts.(string)),
 		}
 		diags = append(diags, ignore_update_stmts_warning)
 	}

--- a/snowsql/resource_exec.go
+++ b/snowsql/resource_exec.go
@@ -154,11 +154,11 @@ func resourceExecCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 	updateStmts, ok := d.GetOk("update.0.statements")
 	if ok {
-		ignore_update_stmt_warning := diag.Diagnostic{
+		ignore_update_stmts_warning := diag.Diagnostic{
 			Severity: diag.Warning,
 			Summary:  fmt.Sprintf("The update statements are ignored during resource creation:\n\nStatements:\n\n  %s", updateStmts.(string)),
 		}
-		diags = append(diags, ignore_update_stmt_warning)
+		diags = append(diags, ignore_update_stmts_warning)
 	}
 
 	name, ok := d.GetOk("name")

--- a/templates/resources/exec.md.tmpl
+++ b/templates/resources/exec.md.tmpl
@@ -80,7 +80,7 @@ Statements can also be formatted across multiple lines for better readability. T
 
 ## Argument Reference
 
-* `name` - (Required, Forces new resource) The name of the resource.
+* `name` - (Optional) The name of the resource. Defaults to random ID.
 * `create` - (Required, Forces new resource) Configuration block for create lifecycle statements. (see [below for nested schema](#nested-blocks---create-read-update-and-delete))
 * `read` - (Optional) Configuration block for read lifecycle statements. (see [below for nested schema](#nested-blocks---create-read-update-and-delete))
 * `update` - (Optional) Configuration block for in-place update lifecycle statements. (see [below for nested schema](###nested-blocks---create-read-update-and-delete))


### PR DESCRIPTION
# Feats
- #81 
- #85 

# Example 1

Removing name after specified during resource creation:

1. Create resource with name:

```terraform
resource "snowsql_exec" "role" {
  name = "my_role"

  create {
    statements = "CREATE ROLE IF NOT EXISTS my_role"
  }

  delete {
    statements = "DROP ROLE IF EXISTS my_role"
  }
}
```
output:
```bash
  # snowsql_exec.role will be created
  + resource "snowsql_exec" "role" {
      + id           = (known after apply)
      + name         = "my_role"
      + read_results = (sensitive value)

      + create {
          + number_of_statements = (known after apply)
          + statements           = "CREATE ROLE IF NOT EXISTS my_role"
        }

      + delete {
          + number_of_statements = (known after apply)
          + statements           = "DROP ROLE IF EXISTS my_role"
        }
    }
```

2. and remove the `name` argument:
```terraform
resource "snowsql_exec" "role" {
  # name = "my_role"

  create {
    statements = "CREATE ROLE IF NOT EXISTS my_role"
  }

  delete {
    statements = "DROP ROLE IF EXISTS my_role"
  }
}
```

output:

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # snowsql_exec.role will be updated in-place
  ~ resource "snowsql_exec" "role" {
        id   = "my_role"
      - name = "my_role" -> null


        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
snowsql_exec.role: Modifying... [id=my_role]
snowsql_exec.role: Modifications complete after 0s [id=my_role]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
The original `id` should persist.

# Example 2

create new resource without specifying the `name` argument:

1. Create resource with name:

```terraform
resource "snowsql_exec" "role" {
  create {
    statements = "CREATE ROLE IF NOT EXISTS my_role"
  }

  delete {
    statements = "DROP ROLE IF EXISTS my_role"
  }
}
```
output:
```bash
   # snowsql_exec.role will be created
  + resource "snowsql_exec" "role" {
      + id           = (known after apply)
      + read_results = (sensitive value)

      + create {
          + number_of_statements = (known after apply)
          + statements           = "CREATE ROLE IF NOT EXISTS my_role"
        }

      + delete {
          + number_of_statements = (known after apply)
          + statements           = "DROP ROLE IF EXISTS my_role"
        }
    }
```

2. and add the `name` argument.
```terraform
resource "snowsql_exec" "role" {
  name = "my_role"

  create {
    statements = "CREATE ROLE IF NOT EXISTS my_role"
  }

  delete {
    statements = "DROP ROLE IF EXISTS my_role"
  }
}
```

output:

```bash
snowsql_exec.role: Refreshing state... [id=cfs3dsqnv5cr4jj9bql0]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # snowsql_exec.role will be updated in-place
  ~ resource "snowsql_exec" "role" {
        id   = "cfs3dsqnv5cr4jj9bql0"
      + name = "my_role"


        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
snowsql_exec.role: Modifying... [id=cfs3dsqnv5cr4jj9bql0]
snowsql_exec.role: Modifications complete after 0s [id=cfs3dsqnv5cr4jj9bql0]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
The original `id` should persist.



